### PR TITLE
Constant support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /composer.lock
 /vendor/
+
+# Cache files
 .php_cs.cache
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/php-stubs/generator.svg?branch=master)](https://travis-ci.com/github/php-stubs/generator)
 
-Use this tool to generate stub declarations for functions, classes, interfaces, and global variables defined in any PHP code.  The stubs can subsequently be used to facilitate IDE completion or static analysis via [Psalm](https://getpsalm.org) or potentially other tools.  Stub generation is particularly useful for code which mixes definitions with side-effects.
+Use this tool to generate stub declarations for functions, classes, interfaces, and global variables defined in any PHP code. The stubs can subsequently be used to facilitate IDE completion or static analysis via [Psalm](https://getpsalm.org) or potentially other tools.  Stub generation is particularly useful for code which mixes definitions with side-effects.
 
 The generator is based on nikic's [PHP-Parser](https://github.com/nikic/PHP-Parser), and the code also relies on several [Symfony](https://symfony.com) components.
 
@@ -155,11 +155,10 @@ The set of symbol types are:
 - `StubsGenerator::DOCUMENTED_GLOBALS`: Global variables, but only those with a doc comment.
 - `StubsGenerator::UNDOCUMENTED_GLOBALS`: Global variable, but only those without a doc comment.
 - `StubsGenerator::GLOBALS`: Shortcut to include both documented and undocumented global variables.
+- `StubsGenerator::CONSTANTS`: Constant declarations.
 - `StubsGenerator::DEFAULT`: Shortcut to include everything _except_ undocumented global variables.
 - `StubsGenerator::ALL`: Shortcut to include everything.
 
 ## TODO
 
-- Add support for constants declared with `const`.
-- Add support for constants declared with `define()`.
-    - Consider parsing function and method bodies for these declarations.
+- Consider parsing function and method bodies for constant declarations.

--- a/src/GenerateStubsCommand.php
+++ b/src/GenerateStubsCommand.php
@@ -33,6 +33,7 @@ class GenerateStubsCommand extends Command
         ['documented-globals', StubsGenerator::DOCUMENTED_GLOBALS],
         ['undocumented-globals', StubsGenerator::UNDOCUMENTED_GLOBALS],
         ['globals', StubsGenerator::GLOBALS],
+        ['constants', StubsGenerator::CONSTANTS],
     ];
 
     /**

--- a/src/NodeVisitor.php
+++ b/src/NodeVisitor.php
@@ -5,6 +5,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
@@ -12,6 +13,7 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Const_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\If_;
@@ -41,6 +43,8 @@ class NodeVisitor extends NodeVisitorAbstract
     private $needsDocumentedGlobals;
     /** @var bool */
     private $needsUndocumentedGlobals;
+    /** @var bool */
+    private $needsConstants;
     /** @var bool */
     private $nullifyGlobals;
 
@@ -79,6 +83,7 @@ class NodeVisitor extends NodeVisitorAbstract
         'classes' => [],
         'interfaces' => [],
         'traits' => [],
+        'constants' => [],
         'globals' => [],
     ];
 
@@ -93,6 +98,7 @@ class NodeVisitor extends NodeVisitorAbstract
         $this->needsInterfaces = ($symbols & StubsGenerator::INTERFACES) !== 0;
         $this->needsDocumentedGlobals = ($symbols & StubsGenerator::DOCUMENTED_GLOBALS) !== 0;
         $this->needsUndocumentedGlobals = ($symbols & StubsGenerator::UNDOCUMENTED_GLOBALS) !== 0;
+        $this->needsConstants = ($symbols & StubsGenerator::CONSTANTS) !== 0;
 
         $this->nullifyGlobals = !empty($config['nullify_globals']);
 
@@ -155,6 +161,14 @@ class NodeVisitor extends NodeVisitorAbstract
             if ($this->nullifyGlobals) {
                 $node->expr->expr = new ConstFetch(new Name('null'));
             }
+        } elseif ($node instanceof Const_) {
+            $this->isInDeclaration = true;
+        } elseif (
+            $node instanceof Expression &&
+            $node->expr instanceof FuncCall &&
+            $node->expr->name->parts[0] === "define"
+        ) {
+            $this->isInDeclaration = true;
         } elseif ($node instanceof If_) {
             if (!$this->isInIf) {
                 // We'll examine the first level inside of an if statement to
@@ -182,6 +196,12 @@ class NodeVisitor extends NodeVisitorAbstract
             || $node instanceof Class_
             || $node instanceof Interface_
             || $node instanceof Trait_
+            || $node instanceof Const_
+            || (
+                $node instanceof Expression &&
+                $node->expr instanceof FuncCall &&
+                $node->expr->name->parts[0] === "define"
+            )
         ) {
             // We're leaving one of these.
             $this->isInDeclaration = false;
@@ -334,6 +354,32 @@ class NodeVisitor extends NodeVisitorAbstract
             return $this->needsTraits
                 && $this->count('traits', $fullyQualifiedName)
                 && !trait_exists($fullyQualifiedName);
+        }
+
+        if ($this->needsConstants) {
+            if ($node instanceof Const_) {
+                $node->consts = \array_filter(
+                    $node->consts,
+                    function (\PhpParser\Node\Const_ $const) {
+                        $fullyQualifiedName = $const->name->name;
+                        return $this->count('constants', $fullyQualifiedName)
+                            && !defined($fullyQualifiedName);
+                    }
+                );
+
+                return count($node->consts) > 0;
+            }
+
+            if (
+                $node instanceof Expression &&
+                $node->expr instanceof FuncCall &&
+                $node->expr->name->parts[0] === "define"
+            ) {
+                $fullyQualifiedName = $node->expr->args[0]->value->value;
+
+                return $this->count('constants', $fullyQualifiedName)
+                    && !defined($fullyQualifiedName);
+            }
         }
 
         if (($this->needsDocumentedGlobals || $this->needsUndocumentedGlobals)

--- a/src/NodeVisitor.php
+++ b/src/NodeVisitor.php
@@ -166,7 +166,7 @@ class NodeVisitor extends NodeVisitorAbstract
         } elseif (
             $node instanceof Expression &&
             $node->expr instanceof FuncCall &&
-            $node->expr->name->parts[0] === "define"
+            $node->expr->name->parts[0] === 'define'
         ) {
             $this->isInDeclaration = true;
         } elseif ($node instanceof If_) {
@@ -200,7 +200,7 @@ class NodeVisitor extends NodeVisitorAbstract
             || (
                 $node instanceof Expression &&
                 $node->expr instanceof FuncCall &&
-                $node->expr->name->parts[0] === "define"
+                $node->expr->name->parts[0] === 'define'
             )
         ) {
             // We're leaving one of these.
@@ -373,7 +373,7 @@ class NodeVisitor extends NodeVisitorAbstract
             if (
                 $node instanceof Expression &&
                 $node->expr instanceof FuncCall &&
-                $node->expr->name->parts[0] === "define"
+                $node->expr->name->parts[0] === 'define'
             ) {
                 $fullyQualifiedName = $node->expr->args[0]->value->value;
 

--- a/src/StubsGenerator.php
+++ b/src/StubsGenerator.php
@@ -67,18 +67,25 @@ class StubsGenerator
     public const GLOBALS = self::DOCUMENTED_GLOBALS | self::UNDOCUMENTED_GLOBALS;
 
     /**
+     * Constant symbol type.
+     *
+     * @var int
+     */
+    public const CONSTANTS = 64;
+
+    /**
      * The default set of symbol types.
      *
      * @var int
      */
-    public const DEFAULT = self::FUNCTIONS | self::CLASSES | self::TRAITS | self::INTERFACES | self::DOCUMENTED_GLOBALS;
+    public const DEFAULT = self::FUNCTIONS | self::CLASSES | self::TRAITS | self::INTERFACES | self::DOCUMENTED_GLOBALS | self::CONSTANTS;
 
     /**
      * Shortcut to include every symbol type.
      *
      * @var int
      */
-    public const ALL = self::FUNCTIONS | self::CLASSES | self::TRAITS | self::INTERFACES | self::GLOBALS;
+    public const ALL = self::FUNCTIONS | self::CLASSES | self::TRAITS | self::INTERFACES | self::GLOBALS | self::CONSTANTS;
 
     /** @var int */
     private $symbols;

--- a/test/NodeVisitorTest.php
+++ b/test/NodeVisitorTest.php
@@ -102,7 +102,7 @@ class NodeVisitorTest extends TestCase
         // Really should be testing AST output, this is just easier...
         $string = trim(
             // https://stackoverflow.com/questions/709669/how-do-i-remove-blank-lines-from-text-in-php
-            preg_replace('/(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+/', '\n', $string)
+            preg_replace("/(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+/", "\n", $string)
         );
         $string = str_replace([
             'abstract public',

--- a/test/NodeVisitorTest.php
+++ b/test/NodeVisitorTest.php
@@ -102,7 +102,7 @@ class NodeVisitorTest extends TestCase
         // Really should be testing AST output, this is just easier...
         $string = trim(
             // https://stackoverflow.com/questions/709669/how-do-i-remove-blank-lines-from-text-in-php
-            preg_replace("/(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+/", "\n", $string)
+            preg_replace('/(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+/', '\n', $string)
         );
         $string = str_replace([
             'abstract public',

--- a/test/NodeVisitorTest.php
+++ b/test/NodeVisitorTest.php
@@ -44,6 +44,7 @@ class NodeVisitorTest extends TestCase
             ['globals', 'globals.nullified', StubsGenerator::GLOBALS, [ 'nullify_globals' => true ]],
             'junk',
             'namespaces',
+            'constants',
         ];
 
         $baseDir = __DIR__ . '/files/';

--- a/test/files/constants.in.php
+++ b/test/files/constants.in.php
@@ -1,0 +1,9 @@
+<?php
+
+/** doc */
+const FOO = 'bar';
+
+/** doc */
+define('FIZ', 'BUZ');
+
+const A = 1, B = 2;

--- a/test/files/constants.out.php
+++ b/test/files/constants.out.php
@@ -1,0 +1,9 @@
+<?php
+
+/** doc */
+const FOO = 'bar';
+
+/** doc */
+\define('FIZ', 'BUZ');
+
+const A = 1, B = 2;

--- a/test/files/junk.in.php
+++ b/test/files/junk.in.php
@@ -34,8 +34,3 @@ echo 'sup';
 return [
     'foo'
 ];
-
-// TODO: We should start parsing constants!
-const FOO = 'bar';
-
-define('FIZ', 'BUZ');


### PR DESCRIPTION
Add support for constant generation, defined with either `const` and `define()`.

### Side Note

I'm dubious about opening the PR here. Initially, I was going to make an issue before starting to work on it; but, unfortunately, for some unknown reason, the Issues pane is not available. This is why I started with a commit having nothing to do with the issue itself. :) 

The [topmost-upstream repository](https://github.com/GiacoCorsiglia/php-stubs-generator) has the most stars, so I first decided to make the progress there. But, I'm now doing it here because of two reasons: (1) the vendor of the repo (`php-stubs`), both for its name and having other stub-related repositories focused, and (2) being more recently updated (also its main maintainer).

So, I'm not really sure whether it's a good decision, but it's better than nothing. :) Waiting for your thoughts on this as well.