### PR TITLE
Ignore inaccessible class child nodes

### DIFF
--- a/src/GenerateStubsCommand.php
+++ b/src/GenerateStubsCommand.php
@@ -62,6 +62,7 @@ class GenerateStubsCommand extends Command
             ->addOption('visitor', null, InputOption::VALUE_REQUIRED, 'Path to a PHP file which returns a `StubsGenerator\NodeVisitor` instance to replace the default node visitor.')
             ->addOption('header', null, InputOption::VALUE_REQUIRED, 'A doc comment to prepend to the top of the generated stubs file.  (Will be added below the opening `<?php` tag.)', '')
             ->addOption('nullify-globals', null, InputOption::VALUE_NONE, 'Initialize all global variables with a value of `null`, instead of their assigned value.')
+            ->addOption('include-inaccessible-class-nodes', null, InputOption::VALUE_NONE, 'Include inaccessible class nodes like private members.')
             ->addOption('stats', null, InputOption::VALUE_NONE, 'Whether to print stats instead of outputting stubs.  Stats will always be printed if --out is provided.');
 
         foreach (self::SYMBOL_OPTIONS as $opt) {
@@ -117,6 +118,7 @@ class GenerateStubsCommand extends Command
         $finder = $this->parseSources($input);
         $generator = new StubsGenerator($this->parseSymbols($input), [
             'nullify_globals' => $input->getOption('nullify-globals'),
+            'include_inaccessible_class_nodes' => $input->getOption('include-inaccessible-class-nodes')
         ]);
 
         $result = $generator->generate($finder, $visitor);

--- a/src/NodeVisitor.php
+++ b/src/NodeVisitor.php
@@ -49,6 +49,8 @@ class NodeVisitor extends NodeVisitorAbstract
     private $needsConstants;
     /** @var bool */
     private $nullifyGlobals;
+    /** @var bool */
+    private $includeInaccessibleClassNodes;
 
     /**
      * @psalm-suppress PropertyNotSetInConstructor
@@ -103,6 +105,7 @@ class NodeVisitor extends NodeVisitorAbstract
         $this->needsConstants = ($symbols & StubsGenerator::CONSTANTS) !== 0;
 
         $this->nullifyGlobals = !empty($config['nullify_globals']);
+        $this->includeInaccessibleClassNodes = ($config['include_inaccessible_class_nodes'] ?? false) === true;
 
         $this->globalNamespace = new Namespace_();
     }
@@ -241,7 +244,7 @@ class NodeVisitor extends NodeVisitorAbstract
             // either a method, property, or constant, or its part of the
             // declaration itself (e.g., `extends`).
 
-            if ($parent instanceof Class_ && ($node instanceof ClassMethod || $node instanceof ClassConst || $node instanceof Property)) {
+            if (!$this->includeInaccessibleClassNodes && $parent instanceof Class_ && ($node instanceof ClassMethod || $node instanceof ClassConst || $node instanceof Property)) {
                 if ($node->isPrivate() || ($parent->isFinal() && $node->isProtected())) {
                     return NodeTraverser::REMOVE_NODE;
                 }

--- a/src/NodeVisitor.php
+++ b/src/NodeVisitor.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Const_;
@@ -19,6 +20,7 @@ use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Trait_;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
@@ -238,6 +240,13 @@ class NodeVisitor extends NodeVisitorAbstract
             // Implies `$parent instanceof ClassLike`, which means $node is a
             // either a method, property, or constant, or its part of the
             // declaration itself (e.g., `extends`).
+
+            if ($parent instanceof Class_ && ($node instanceof ClassMethod || $node instanceof ClassConst || $node instanceof Property)) {
+                if ($node->isPrivate() || ($parent->isFinal() && $node->isProtected())) {
+                    return NodeTraverser::REMOVE_NODE;
+                }
+            }
+
             return;
         }
 

--- a/test/NodeVisitorTest.php
+++ b/test/NodeVisitorTest.php
@@ -36,6 +36,7 @@ class NodeVisitorTest extends TestCase
     {
         $cases = [
             'classes',
+            ['classes', 'classes-include-inaccessible-class-nodes', null, ['include_inaccessible_class_nodes' => true]],
             'classes-with-dependencies',
             'circular-dependency',
             'functions',

--- a/test/files/classes-include-inaccessible-class-nodes.out.php
+++ b/test/files/classes-include-inaccessible-class-nodes.out.php
@@ -1,0 +1,73 @@
+<?php
+/** doc */
+abstract class A extends \B implements \C
+{
+    /** doc */
+    protected const A = 'B';
+
+    /** doc */
+    private const B = 'C';
+
+    /** doc */
+    public static $a = 'a';
+
+    private static $b = 'b';
+
+    /** doc */
+    public static function b($a): void
+    {
+    }
+
+    /** doc */
+    abstract public function c($a): string;
+
+    /** doc */
+    protected function d($a) : void
+    {
+    }
+
+    /** doc */
+    protected abstract function e($a) : string;
+
+    /** doc */
+    private function f($a): void
+    {
+    }
+}
+
+class D
+{
+    public function a(string $a): string
+    {
+    }
+}
+
+final class E
+{
+    /** doc */
+    public $a = 'a';
+
+    /** doc */
+    protected $b = 'b';
+
+    /** doc */
+    public function a($a) : void
+    {
+    }
+
+    /** doc */
+    protected function b($a): void
+    {
+    }
+}
+
+trait F
+{
+    /** doc */
+    private $a = 'a';
+
+    /** doc */
+    private function a($a) : void
+    {
+    }
+}

--- a/test/files/classes.in.php
+++ b/test/files/classes.in.php
@@ -6,7 +6,12 @@ abstract class A extends B implements C
     protected const A = 'B';
 
     /** doc */
+    private const B = 'C';
+
+    /** doc */
     public static $a = 'a';
+
+    private static $b = 'b';
 
     /** doc */
     public static function b($a): void
@@ -16,6 +21,21 @@ abstract class A extends B implements C
 
     /** doc */
     abstract public function c($a): string;
+
+    /** doc */
+    protected function d($a): void
+    {
+        return;
+    }
+
+    /** doc */
+    abstract protected function e($a): string;
+
+    /** doc */
+    private function f($a): void
+    {
+        return;
+    }
 }
 
 if (!class_exists('D')) {
@@ -25,5 +45,38 @@ if (!class_exists('D')) {
         {
             return '';
         }
+    }
+}
+
+final class E
+{
+    /** doc */
+    public $a = 'a';
+
+    /** doc */
+    protected $b = 'b';
+
+    /** doc */
+    public function a($a): void
+    {
+        return;
+    }
+
+    /** doc */
+    protected function b($a): void
+    {
+        return;
+    }
+}
+
+trait F
+{
+    /** doc */
+    private $a = 'a';
+
+    /** doc */
+    private function a($a): void
+    {
+        return;
     }
 }

--- a/test/files/classes.out.php
+++ b/test/files/classes.out.php
@@ -15,11 +15,41 @@ abstract class A extends \B implements \C
 
     /** doc */
     abstract public function c($a): string;
+
+    /** doc */
+    protected function d($a) : void
+    {
+    }
+
+    /** doc */
+    protected abstract function e($a) : string;
 }
 
 class D
 {
     public function a(string $a): string
+    {
+    }
+}
+
+final class E
+{
+    /** doc */
+    public $a = 'a';
+
+    /** doc */
+    public function a($a) : void
+    {
+    }
+}
+
+trait F
+{
+    /** doc */
+    private $a = 'a';
+
+    /** doc */
+    private function a($a) : void
     {
     }
 }


### PR DESCRIPTION
Based on the idea that was voiced in https://github.com/szepeviktor/phpstan-wordpress/issues/99#issuecomment-1112996660

It should be safe to not include private constants/properties/methods of classes. And if the class is final, protected ones can be ignored too IMO.

Fyi this only makes the wordpress-stubs around 0.1M smaller, so it won't change much in regard to parsing performance there.

What do you think?