### PR TITLE
Adjust logic targeting inaccessible nodes

### DIFF
--- a/src/NodeVisitor.php
+++ b/src/NodeVisitor.php
@@ -244,10 +244,12 @@ class NodeVisitor extends NodeVisitorAbstract
             // either a method, property, or constant, or its part of the
             // declaration itself (e.g., `extends`).
 
-            if (!$this->includeInaccessibleClassNodes && $parent instanceof Class_ && ($node instanceof ClassMethod || $node instanceof ClassConst || $node instanceof Property)) {
-                if ($node->isPrivate() || ($parent->isFinal() && $node->isProtected())) {
-                    return NodeTraverser::REMOVE_NODE;
-                }
+            if (!$this->includeInaccessibleClassNodes
+                && $parent instanceof Class_
+                && ($node instanceof ClassMethod || $node instanceof ClassConst || $node instanceof Property)
+                && ($node->isPrivate() || $node->isProtected())
+            ) {
+                return NodeTraverser::REMOVE_NODE;
             }
 
             return;

--- a/test/files/classes.out.php
+++ b/test/files/classes.out.php
@@ -3,9 +3,6 @@
 abstract class A extends \B implements \C
 {
     /** doc */
-    protected const A = 'B';
-
-    /** doc */
     public static $a = 'a';
 
     /** doc */
@@ -15,14 +12,6 @@ abstract class A extends \B implements \C
 
     /** doc */
     abstract public function c($a): string;
-
-    /** doc */
-    protected function d($a) : void
-    {
-    }
-
-    /** doc */
-    protected abstract function e($a) : string;
 }
 
 class D
@@ -46,21 +35,7 @@ final class E
 trait F
 {
     /** doc */
-    private $a = 'a';
-
-    /** doc */
-    private function a($a) : void
-    {
-    }
-
-    /** doc */
     abstract public function b($a): string;
-
-    /** doc */
-    abstract protected function c($a): string;
-
-    /** doc */
-    abstract private function d($a): string;
 }
 
 final class G


### PR DESCRIPTION
### Changes

- Loosen parent check from `Class_` to `ClassLike` to include `Traits`, `Interfaces`, and `Enums`.
- Remove protected nodes, regardless if the class is final or not. 
- Adjust test

### Reason
Unfortunately, sometimes developers define protected or private methods in interfaces.

I'm looking at you WooCommerce:

```
Fatal error: Class WC_Cart_Totals contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (WC_Cart_Totals::get_values_for_total) in woocommerce-stubs.php on line 15030
```

The missing abstract method (`get_values_for_total`) is defined in a trait: 
https://github.com/woocommerce/woocommerce/blob/c4a7e9a11b62e9f62fd507f5a0c8ae09740619a0/plugins/woocommerce/includes/traits/trait-wc-item-totals.php#L32
