### PR TITLE
Add support for PhpParser v5 for PHP 7.4+

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+block_comment_start = /*
+block_comment = *
+block_comment_end = */

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 /vendor/
 
 # Cache files
-.php_cs.cache
-.phpunit.result.cache
+*.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,12 +1,12 @@
 <?php
-// http://cs.sensiolabs.org/#usage
-$finder = PhpCsFixer\Finder::create()
+// https://cs.symfony.com/doc/usage.html
+$finder = (new PhpCsFixer\Finder())
     ->in(__DIR__ . '/src')
     ->in(__DIR__ . '/test')
     ->in(__DIR__ . '/bin')
 ;
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules([
         // If you're curious what these do, use `php-cs-fixer describe <key>`
         '@PSR1' => true,
@@ -19,9 +19,9 @@ return PhpCsFixer\Config::create()
         'function_typehint_space' => true,
         'include' => true,
         'linebreak_after_opening_tag' => true,
-        // 'list_syntax' => ['syntax' => 'short'], Requires PHP 7.1
+        'list_syntax' => ['syntax' => 'short'],
         'magic_constant_casing' => true,
-        'method_separation' => true,
+        'class_attributes_separation' => ['elements' => ['method' => 'one']],
         'native_function_casing' => true,
         'new_with_braces' => true,
         'no_blank_lines_after_class_opening' => true,
@@ -34,7 +34,7 @@ return PhpCsFixer\Config::create()
         'no_unused_imports' => true,
         'normalize_index_brace' => true,
         'not_operator_with_successor_space' => false,
-        'ordered_imports' => ['sortAlgorithm' => 'alpha'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
         'phpdoc_indent' => true,
         'phpdoc_order' => true,
         'phpdoc_scalar' => true,
@@ -49,5 +49,4 @@ return PhpCsFixer\Config::create()
         'whitespace_after_comma_in_array' => true,
     ])
     ->setFinder($finder)
-    ->setCacheFile(__DIR__ . '/.php_cs.cache')
 ;

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "nikic/php-parser": "^4.10",
-        "symfony/console": "^5.1 || ^6.0",
+        "symfony/console": "^5.1 || ^6.0 || ^7.0",
         "symfony/filesystem": "^5.0 || ^6.0 || ^7.0",
-        "symfony/finder": "^5.0 || ^6.0"
+        "symfony/finder": "^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "vimeo/psalm": "^4.1",

--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,17 @@
         "symfony/finder": "^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.4",
-        "friendsofphp/php-cs-fixer": "^2.16 || ^3.12"
+        "friendsofphp/php-cs-fixer": "3.4.0 || ^3.12",
+        "phpstan/phpstan": "^1.0 || ^2.0",
+        "phpunit/phpunit": "^9.4"
     },
     "scripts": {
-        "test": "phpunit --verbose"
+        "test": "phpunit --verbose",
+        "cs:check": "php-cs-fixer check",
+        "cs:fix": "php-cs-fixer fix",
+        "phpstan": "phpstan analyse"
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,12 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "nikic/php-parser": "^4.10",
+        "nikic/php-parser": "^4.10 || ^5.1",
         "symfony/console": "^5.1 || ^6.0 || ^7.0",
         "symfony/filesystem": "^5.0 || ^6.0 || ^7.0",
         "symfony/finder": "^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
-        "vimeo/psalm": "^4.1",
         "phpunit/phpunit": "^9.4",
         "friendsofphp/php-cs-fixer": "^2.16 || ^3.12"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": "^7.3 || ^8.0",
         "nikic/php-parser": "^4.10",
         "symfony/console": "^5.1 || ^6.0",
-        "symfony/filesystem": "^5.0 || ^6.0",
+        "symfony/filesystem": "^5.0 || ^6.0 || ^7.0",
         "symfony/finder": "^5.0 || ^6.0"
     },
     "require-dev": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+    level: max
+    paths:
+        - src

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,16 +1,16 @@
 <!--bootstrap="tests/bootstrap.php" -->
 <phpunit
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.4/phpunit.xsd"
-	backupGlobals="false"
-	beStrictAboutChangesToGlobalState="true"
-	beStrictAboutCoversAnnotation="true"
-	beStrictAboutOutputDuringTests="true"
-	beStrictAboutTestsThatDoNotTestAnything="true"
-	colors="true"
-	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.4/phpunit.xsd"
+    backupGlobals="false"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutCoversAnnotation="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
 >
     <testsuites>
         <testsuite name="Stub Generator Tests">

--- a/src/NodeVisitor.php
+++ b/src/NodeVisitor.php
@@ -172,7 +172,7 @@ class NodeVisitor extends NodeVisitorAbstract
             $node instanceof Expression &&
             $node->expr instanceof FuncCall &&
             $node->expr->name instanceof Name &&
-            $node->expr->name->parts[0] === 'define'
+            $node->expr->name->getFirst() === 'define'
         ) {
             $this->isInDeclaration = true;
         } elseif ($node instanceof If_) {
@@ -207,7 +207,7 @@ class NodeVisitor extends NodeVisitorAbstract
                 $node instanceof Expression &&
                 $node->expr instanceof FuncCall &&
                 $node->expr->name instanceof Name &&
-                $node->expr->name->parts[0] === 'define'
+                $node->expr->name->getFirst() === 'define'
             )
         ) {
             // We're leaving one of these.
@@ -388,7 +388,7 @@ class NodeVisitor extends NodeVisitorAbstract
                 $node instanceof Expression &&
                 $node->expr instanceof FuncCall &&
                 $node->expr->name instanceof Name &&
-                $node->expr->name->parts[0] === 'define'
+                $node->expr->name->getFirst() === 'define'
             ) {
                 $fullyQualifiedName = $node->expr->args[0]->value->value;
 

--- a/src/StubsGenerator.php
+++ b/src/StubsGenerator.php
@@ -112,10 +112,10 @@ class StubsGenerator
      */
     public function generate(Finder $finder, NodeVisitor $visitor = null): Result
     {
-        $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
 
         if (!($visitor instanceof NodeVisitor)) {
-            $visitor = new NodeVisitor;
+            $visitor = new NodeVisitor();
         }
 
         $visitor->init($this->symbols, $this->config);

--- a/test/NodeVisitorTest.php
+++ b/test/NodeVisitorTest.php
@@ -12,7 +12,7 @@ class NodeVisitorTest extends TestCase
 {
     private function parse(string $php, int $symbols, array $config): NodeVisitor
     {
-        $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
 
         $traverser = new NodeTraverser();
         $traverser->addVisitor(new NameResolver());


### PR DESCRIPTION
This PR adds support for `nikic/php-parser` v5 for PHP 7.4+, while retaining compatibility with v4 for PHP 7.3.

### Key Changes

- The `parts` property of `PhpParser\Node\Name` was deprecated in v4 and removed in v5. It has been replaced with a call to `getFirst()`, which is available in both major versions.
- The `create()` method and the `PREFER_PHP7` constant were removed from `PhpParser\ParserFactory` in v5. This PR uses the `createForNewestSupportedVersion()` method instead, which is available in both v4 and v5. According to the [upgrade guide](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md), this method is "roughly equivalent to PREFER_PHP7 behavior".

### Testing

The changes were tested with `php-stubs/wordpress`. Output under v5 (5.4.0) differs slightly but improves correctness:
- No longer adds incorrect slashes.
- Preserves the correct order of `final` and visibility modifiers.

Closes #25 
Closes #31