### PR TITLE
Explicit nullable type hint for PHP 8.4

### DIFF
--- a/src/NodeVisitor.php
+++ b/src/NodeVisitor.php
@@ -426,7 +426,7 @@ class NodeVisitor extends NodeVisitorAbstract
      * @return bool If true, this is the first declaration of this type with
      *              this name, so it can be safely included.
      */
-    private function count(string $type, string $name = null): bool
+    private function count(string $type, ?string $name = null): bool
     {
         assert(isset($this->counts[$type]), 'Expected valid `$type`');
 

--- a/src/Result.php
+++ b/src/Result.php
@@ -105,7 +105,7 @@ class Result implements IteratorAggregate
      *
      * @return string The pretty printed version.
      */
-    public function prettyPrint(PrettyPrinterAbstract $printer = null): string
+    public function prettyPrint(?PrettyPrinterAbstract $printer = null): string
     {
         if (!$printer) {
             $printer = new Standard();

--- a/src/StubsGenerator.php
+++ b/src/StubsGenerator.php
@@ -106,11 +106,11 @@ class StubsGenerator
      * pretty-printed stubs.
      *
      * @param Finder $finder The set of files to generate (merged) stubs for.
-     * @param NodeVisitor $visitor The optional node visitor to override the default.
+     * @param NodeVisitor|null $visitor The optional node visitor to override the default.
      *
      * @return Result
      */
-    public function generate(Finder $finder, NodeVisitor $visitor = null): Result
+    public function generate(Finder $finder, ?NodeVisitor $visitor = null): Result
     {
         $parser = (new ParserFactory())->createForNewestSupportedVersion();
 


### PR DESCRIPTION
Avoid E_DEPRECATED warnings