### PR TITLE
Bump nikic/php-parser versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "nikic/php-parser": "^4.10 || ^5.1",
+        "nikic/php-parser": "^4.18 || ^5.5",
         "symfony/console": "^5.1 || ^6.0 || ^7.0",
         "symfony/filesystem": "^5.0 || ^6.0 || ^7.0",
         "symfony/finder": "^5.0 || ^6.0 || ^7.0"


### PR DESCRIPTION
This PR updates the minimum supported versions of `nikic/php-parser` for both the v4 and v5 dependency lines.

### Version 4: bump from `4.10` to `4.18`

PR #33 added support for PHP 7.4+ by replacing the call to `PhpParser\ParserFactory::create()` with `PhpParser\ParserFactory::createForNewestSupportedVersion()`. `createForNewestSupportedVersion()` is only available starting with `nikic/php-parser` `4.18`, and the minimum required v4 version was not updated accordingly.

Bumping the minimum v4 version to `4.18` removes the risk of calling an undefined method.

### Version 5: bump from `5.1` to `5.5`

Starting with [`nikic/php-parser` 5.5.0](https://github.com/nikic/PHP-Parser/releases/tag/v5.5.0), attribute printing was fixed to work correctly on PHP versions < 8.0 (also see the related issue: https://github.com/nikic/PHP-Parser/issues/1081). The minimum required v5 version has not been updated since.

Bumping the minimum v5 version to `5.5` removes the risk of generating stubs that might cause parse errors when running on PHP < 8.0.

### For discussion

The attribute-printing fix was not backported to the v4 line. If it is intended to keep supporting `nikic/php-parser` v4, it may be better to explicitly document that attribute printing on PHP < 8.0 remains unfixed there. Alternatively, support for v4 could be dropped.
